### PR TITLE
test(utils): add coverage for file reading and logging

### DIFF
--- a/internal/importer/issues.go
+++ b/internal/importer/issues.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
 	"time"
 
 	"github.com/bnidev/trac2gitlab/internal/config"
@@ -32,7 +33,7 @@ func ImportIssues(client *gitlab.Client, config *config.Config) error {
 
 	fmt.Printf("Importing issues for project: %s (ID: %d)\n", project.Name, project.ID)
 
-	issues, err := utils.ReadFilesFromDir("data/tickets", ".json")
+	issues, err := utils.ReadFilesFromDir("data/tickets", ".json", os.Stderr)
 	if err != nil {
 		return fmt.Errorf("failed to read milestones from directory: %w", err)
 	}

--- a/internal/importer/milestones.go
+++ b/internal/importer/milestones.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
 	"time"
 
 	"github.com/bnidev/trac2gitlab/internal/config"
@@ -36,7 +37,7 @@ func ImportMilestones(client *gitlab.Client, config *config.Config) error {
 	fmt.Printf("Importing milestones for project: %s (ID: %d)\n", project.Name, project.ID)
 
 	// Import milestones from exported Trac data
-	milestones, err := utils.ReadFilesFromDir("data/milestones", ".json")
+	milestones, err := utils.ReadFilesFromDir("data/milestones", ".json", os.Stderr)
 	if err != nil {
 		return fmt.Errorf("failed to read milestones from directory: %w", err)
 	}

--- a/internal/utils/files.go
+++ b/internal/utils/files.go
@@ -2,13 +2,14 @@ package utils
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 )
 
 // ReadFilesFromDir reads all files with the given extension from the specified directory.
-func ReadFilesFromDir(dirPath string, fileType string) ([][]byte, error) {
+func ReadFilesFromDir(dirPath string, fileType string, warnWriter io.Writer) ([][]byte, error) {
 	allowedTypes := map[string]bool{".json": true, ".md": true}
 	if fileType == "" {
 		fileType = ".json"
@@ -38,7 +39,11 @@ func ReadFilesFromDir(dirPath string, fileType string) ([][]byte, error) {
 			fullPath := filepath.Join(dirPath, entry.Name())
 			content, err := os.ReadFile(fullPath)
 			if err != nil {
-				fmt.Printf("Warning: failed to read file %s: %v\n", fullPath, err)
+				if warnWriter != nil {
+					if _, err = fmt.Fprintf(warnWriter, "Warning: failed to read file %s: %v\n", fullPath, err); err != nil {
+						return nil, fmt.Errorf("failed to write warning: %w", err)
+					}
+				}
 				continue
 			}
 			results = append(results, content)

--- a/internal/utils/files_test.go
+++ b/internal/utils/files_test.go
@@ -15,7 +15,7 @@ import (
 func TestReadFilesFromDir(t *testing.T) {
 	dir := t.TempDir()
 
-	// Helper to create a file nith content
+	// Helper to create a file with content
 	createFile := func(name, content string) {
 		err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644)
 		if err != nil {

--- a/internal/utils/files_test.go
+++ b/internal/utils/files_test.go
@@ -1,0 +1,129 @@
+package utils_test
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"fmt"
+
+	"github.com/bnidev/trac2gitlab/internal/utils"
+)
+
+func TestReadFilesFromDir(t *testing.T) {
+	dir := t.TempDir()
+
+	// Helper to create a file nith content
+	createFile := func(name, content string) {
+		err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644)
+		if err != nil {
+			t.Fatalf("failed to create test file %s: %v", name, err)
+		}
+	}
+
+	// Create some files and a subdir
+	createFile("file1.json", `{"foo":1}`)
+	createFile("file2.md", "# title")
+	createFile("file3.txt", "ignored")
+	fileErr := os.Mkdir(filepath.Join(dir, "subdir"), 0755)
+	if fileErr != nil {
+		t.Fatalf("failed to create subdir: %v", fileErr)
+	}
+
+	// Also create a file with no read permission (to test skipping)
+	noReadFile := filepath.Join(dir, "file4.json")
+	err := os.WriteFile(noReadFile, []byte("unreadable"), 0000)
+	if err != nil {
+		t.Fatalf("failed to create unreadable file: %v", err)
+	}
+	defer func() {
+		if err = os.Chmod(noReadFile, 0644); err != nil {
+			t.Fatalf("failed to restore permissions for %s: %v", noReadFile, err)
+		}
+	}()
+
+	t.Run("Default filetype is json", func(t *testing.T) {
+		files, err := utils.ReadFilesFromDir(dir, "", io.Discard)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(files) != 1 {
+			t.Fatalf("expected 1 json file, got %d", len(files))
+		}
+		if !strings.Contains(string(files[0]), `"foo":1`) {
+			t.Errorf("unexpected file content: %s", string(files[0]))
+		}
+	})
+
+	t.Run("Explicit md filetype", func(t *testing.T) {
+		files, err := utils.ReadFilesFromDir(dir, ".md", io.Discard)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(files) != 1 {
+			t.Fatalf("expected 1 md file, got %d", len(files))
+		}
+		if !strings.Contains(string(files[0]), "title") {
+			t.Errorf("unexpected file content: %s", string(files[0]))
+		}
+	})
+
+	t.Run("Filetype without dot", func(t *testing.T) {
+		files, err := utils.ReadFilesFromDir(dir, "md", io.Discard)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(files) != 1 {
+			t.Fatalf("expected 1 md file, got %d", len(files))
+		}
+	})
+
+	t.Run("Unsupported filetype", func(t *testing.T) {
+		_, err := utils.ReadFilesFromDir(dir, ".txt", io.Discard)
+		if err == nil {
+			t.Fatal("expected error for unsupported filetype")
+		}
+	})
+
+	t.Run("Skip directories", func(t *testing.T) {
+		files, err := utils.ReadFilesFromDir(dir, ".json", io.Discard)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for _, content := range files {
+			if strings.Contains(string(content), "subdir") {
+				t.Errorf("directory content included unexpectedly")
+			}
+		}
+	})
+
+	t.Run("Skip unreadable files", func(t *testing.T) {
+		files, err := utils.ReadFilesFromDir(dir, ".json", io.Discard)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// The unreadable file should be skipped, so total json files read should be 1 (file1.json)
+		if len(files) != 1 {
+			t.Errorf("expected 1 json file, got %d", len(files))
+		}
+	})
+
+	t.Run("File limit enforced", func(t *testing.T) {
+		// Create more than 1000 json files
+		for i := range 1100 {
+			fname := filepath.Join(dir, "file"+fmt.Sprint(i)+"_limit.json")
+			if err = os.WriteFile(fname, []byte(`{"num":`+fmt.Sprint(i)+`}`), 0644); err != nil {
+				t.Fatalf("failed to create test file %s: %v", fname, err)
+			}
+		}
+		files, err := utils.ReadFilesFromDir(dir, ".json", io.Discard)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(files) > 1000 {
+			t.Errorf("expected at most 1000 files, got %d", len(files))
+		}
+	})
+}

--- a/internal/utils/files_test.go
+++ b/internal/utils/files_test.go
@@ -112,7 +112,9 @@ func TestReadFilesFromDir(t *testing.T) {
 
 	t.Run("File limit enforced", func(t *testing.T) {
 		// Create more than 1000 json files
-		for i := range 1100 {
+		const testFilesAboveLimit = 1100
+		// Create more than 1000 json files
+		for i := range testFilesAboveLimit {
 			fname := filepath.Join(dir, "file"+fmt.Sprint(i)+"_limit.json")
 			if err = os.WriteFile(fname, []byte(`{"num":`+fmt.Sprint(i)+`}`), 0644); err != nil {
 				t.Fatalf("failed to create test file %s: %v", fname, err)

--- a/internal/utils/logger.go
+++ b/internal/utils/logger.go
@@ -57,6 +57,8 @@ func (h *PrettyHandler) WithGroup(name string) slog.Handler {
 
 func styledLevel(level slog.Level) (string, lipgloss.Style) {
 	var code string
+	levelStr := level.String()
+
 	switch level {
 	case slog.LevelDebug:
 		code = "8" // gray
@@ -71,7 +73,7 @@ func styledLevel(level slog.Level) (string, lipgloss.Style) {
 	}
 
 	style := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(code))
-	return style.Render("[" + level.String() + "]"), style
+	return style.Render("[" + levelStr + "]"), style
 }
 
 func parseLevel(s string) slog.Level {

--- a/internal/utils/logger_test.go
+++ b/internal/utils/logger_test.go
@@ -1,0 +1,120 @@
+package utils
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"log/slog"
+)
+
+func TestParseLevel(t *testing.T) {
+	tests := []struct {
+		input string
+		want  slog.Level
+	}{
+		{"debug", slog.LevelDebug},
+		{"info", slog.LevelInfo},
+		{"warn", slog.LevelWarn},
+		{"error", slog.LevelError},
+		{"unknown", slog.LevelInfo}, // default
+	}
+
+	for _, tt := range tests {
+		got := parseLevel(tt.input)
+		if got != tt.want {
+			t.Errorf("parseLevel(%q) = %v; want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestPrettyHandler_Enabled(t *testing.T) {
+	handler := NewPrettyHandler(slog.LevelInfo)
+
+	if !handler.Enabled(context.Background(), slog.LevelInfo) {
+		t.Error("Enabled returned false for level equal to minLevel")
+	}
+
+	if !handler.Enabled(context.Background(), slog.LevelError) {
+		t.Error("Enabled returned false for level higher than minLevel")
+	}
+
+	if handler.Enabled(context.Background(), slog.LevelDebug) {
+		t.Error("Enabled returned true for level lower than minLevel")
+	}
+}
+
+func TestPrettyHandler_Handle(t *testing.T) {
+	handler := NewPrettyHandler(slog.LevelDebug)
+
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	attrs := []slog.Attr{
+		slog.String("key1", "value1"),
+		slog.Int("key2", 42),
+	}
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "test message", 0)
+	record.AddAttrs(attrs...)
+
+	err := handler.Handle(context.Background(), record)
+	errClose := w.Close()
+	if errClose != nil {
+		t.Fatalf("failed to close pipe writer: %v", errClose)
+	}
+
+	os.Stderr = oldStderr
+
+	if err != nil {
+		t.Errorf("Handle returned error: %v", err)
+	}
+
+	// Read from pipe
+	var outputBuf bytes.Buffer
+	_, err = outputBuf.ReadFrom(r)
+	if err != nil {
+		t.Fatalf("failed to read stderr pipe: %v", err)
+	}
+
+	output := outputBuf.String()
+
+	// Check timestamp format (simple check)
+	if len(output) < 20 || output[4] != '/' || output[7] != '/' {
+		t.Errorf("Output timestamp format incorrect: %q", output)
+	}
+
+	// Check level string is present
+	if !strings.Contains(output, "[INFO]") {
+		t.Errorf("Output missing level string: %q", output)
+	}
+
+	// Check message and attrs presence
+	if !strings.Contains(output, "test message") || !strings.Contains(output, "key1=value1") || !strings.Contains(output, "key2=42") {
+		t.Errorf("Output missing message or attributes: %q", output)
+	}
+}
+
+func TestStyledLevel(t *testing.T) {
+	tests := []struct {
+		level    slog.Level
+		expected string
+	}{
+		{slog.LevelDebug, "[DEBUG]"},
+		{slog.LevelInfo, "[INFO]"},
+		{slog.LevelWarn, "[WARN]"},
+		{slog.LevelError, "[ERROR]"},
+		{slog.Level(999), "[" + slog.Level(999).String() + "]"}, // unknown/custom levels
+	}
+
+	for _, tt := range tests {
+		got, _ := styledLevel(tt.level)
+		if !strings.Contains(got, tt.expected) {
+			t.Errorf("styledLevel(%v) = %q; want to contain %q", tt.level, got, tt.expected)
+		}
+	}
+}


### PR DESCRIPTION
This PR improves test coverage and refines behavior in the utils package:

- Unit tests for `ReadFilesFromDir`, covering:
  - File type filtering
  - Directory skipping
  - Unreadable file handling
  - Max file limit enforcement
- Unit tests for `PrettyHandler` and `styledLevel` in the logger
