### PR TITLE
feat(export): support exporting additional ticket fields

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,13 +38,14 @@ type GitLabConfig struct {
 
 // ExportOptions holds the options for exporting data from Trac
 type ExportOptions struct {
-	IncludeWiki          bool   `yaml:"include_wiki"`
-	IncludeAttachments   bool   `yaml:"include_attachments"`
-	IncludeTicketHistory bool   `yaml:"include_ticket_history"`
-	IncludeClosedTickets bool   `yaml:"include_closed_tickets"`
-	IncludeTicketFields  bool   `yaml:"include_ticket_fields"`
-	IncludeUsers         bool   `yaml:"include_users"`
-	ExportDir            string `yaml:"export_dir"`
+	IncludeWiki            bool     `yaml:"include_wiki"`
+	IncludeAttachments     bool     `yaml:"include_attachments"`
+	IncludeTicketHistory   bool     `yaml:"include_ticket_history"`
+	IncludeClosedTickets   bool     `yaml:"include_closed_tickets"`
+	IncludeTicketFields    bool     `yaml:"include_ticket_fields"`
+	AdditionalTicketFields []string `yaml:"additional_ticket_fields"`
+	IncludeUsers           bool     `yaml:"include_users"`
+	ExportDir              string   `yaml:"export_dir"`
 }
 
 // ImportOptions holds the options for importing data into GitLab

--- a/internal/exporter/ticket_fields.go
+++ b/internal/exporter/ticket_fields.go
@@ -22,17 +22,24 @@ type ExportTicketField struct {
 func ExportTicketFields(client *trac.Client, config *config.Config) error {
 	slog.Info("Starting ticket field export...")
 
-	var defaultFields = []string{"priority", "component", "type"}
+	defaultFields := []string{"priority", "component", "type"}
+	additionalFields := config.ExportOptions.AdditionalTicketFields
 
 	fields, err := client.GetTicketFields()
 	if err != nil {
 		return fmt.Errorf("failed to get ticket fields: %w", err)
 	}
+
 	var exportFields []ExportTicketField
+
 	for _, field := range fields {
 		if slices.Contains(defaultFields, field.Name) {
-			// add field.Name and field.Options to export struct
 			slog.Debug("Default field found", "fieldName", field.Name, "options", field.Options)
+			appendedField := createExportTicketField(field)
+			exportFields = append(exportFields, appendedField)
+		}
+		if slices.Contains(additionalFields, field.Name) {
+			slog.Debug("Additional field found", "fieldName", field.Name, "options", field.Options)
 			appendedField := createExportTicketField(field)
 			exportFields = append(exportFields, appendedField)
 		}

--- a/internal/exporter/ticket_fields.go
+++ b/internal/exporter/ticket_fields.go
@@ -32,16 +32,14 @@ func ExportTicketFields(client *trac.Client, config *config.Config) error {
 
 	var exportFields []ExportTicketField
 
+	processed := make(map[string]bool)
+
 	for _, field := range fields {
-		if slices.Contains(defaultFields, field.Name) {
-			slog.Debug("Default field found", "fieldName", field.Name, "options", field.Options)
+		if (slices.Contains(defaultFields, field.Name) || slices.Contains(additionalFields, field.Name)) && !processed[field.Name] {
+			slog.Debug("Field added", "fieldName", field.Name, "options", field.Options)
 			appendedField := createExportTicketField(field)
 			exportFields = append(exportFields, appendedField)
-		}
-		if slices.Contains(additionalFields, field.Name) {
-			slog.Debug("Additional field found", "fieldName", field.Name, "options", field.Options)
-			appendedField := createExportTicketField(field)
-			exportFields = append(exportFields, appendedField)
+			processed[field.Name] = true
 		}
 	}
 


### PR DESCRIPTION
This PR adds support for exporting additional, user-specified ticket fields during the ticket field export process.

## Changes

- Added a new field AdditionalTicketFields ([]string) to ExportOptions in the config, allowing users to specify extra ticket fields to export.
-  Modified the ExportTicketFields function to include both the default ticket fields ("priority", "component", "type") and any fields listed in AdditionalTicketFields.
-  Updated the logic to log and export these additional fields if they are present.

## How to use

In the configuration file, add the `additional_ticket_fields` key under `export_options`. For example:
```yaml
export_options:
  additional_ticket_fields:
    - severity
    - milestone
```